### PR TITLE
fix: call game.destroy() when finalize

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -260,6 +260,7 @@ export function initialize(param: InitializeParameter): () => void {
 			window.cancelAnimationFrame(requestAnimationFrameId);
 			requestAnimationFrameId = null;
 		}
+		game._destroy();
 		unhandlePointEvent();
 		primarySurface.renderer().clear();
 	};


### PR DESCRIPTION
# このPullRequestが解決する内容
`finalize()` (`initialize()` の戻り値) の実行時に `g.Game#_destroy()` を呼び忘れていたため、明示的に呼ぶように修正します。